### PR TITLE
feat: optional addon password in .env that protects config and streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,15 @@ MANIFEST_BLURB=Version communautaire - Merci de votre soutien!
 
 **Utilité** : Permet d'afficher des informations supplémentaires, liens de support, etc.
 
+### ADDON_PASSWORD
+
+Protège l'accès à la génération du manifest par un mot de passe.
+
+```bash
+# Exemple
+ADDON_PASSWORD=mot_de_passe
+```
+
 ### Exemple complet avec Docker Compose
 
 ```yaml
@@ -339,6 +348,7 @@ environment:
   - QBITTORRENT_ENABLE=false
   - MANIFEST_TITLE_SUFFIX=| ElfHosted
   - MANIFEST_BLURB=<b>Premium hosting by ElfHosted</b> - <a href="https://elfhosted.com/support">Support</a>
+  - ADDON_PASSWORD=mot_de_passe
 ```
 
 ## 🔧 Configuration qBittorrent

--- a/main.py
+++ b/main.py
@@ -72,12 +72,15 @@ STREMIO_ADDONS_CONFIG = {
 QBITTORRENT_ENABLE = os.getenv('QBITTORRENT_ENABLE', 'true').lower() in ('true', '1', 'yes')
 MANIFEST_TITLE_SUFFIX = os.getenv('MANIFEST_TITLE_SUFFIX', '')
 MANIFEST_BLURB = os.getenv('MANIFEST_BLURB', '')
+ADDON_PASSWORD = os.getenv('ADDON_PASSWORD', '')
 
 logging.info(f"qBittorrent enabled: {QBITTORRENT_ENABLE}")
 if MANIFEST_TITLE_SUFFIX:
     logging.info(f"Manifest title suffix: {MANIFEST_TITLE_SUFFIX}")
 if MANIFEST_BLURB:
     logging.info(f"Manifest blurb configured")
+if ADDON_PASSWORD:
+    logging.info(f"Addon password protection enabled")
 
 # ============================================================================
 # Middleware
@@ -100,6 +103,19 @@ async def cors_middleware(request, handler):
 # ============================================================================
 # Configuration Handlers
 # ============================================================================
+
+async def handle_verify_password(request):
+    """Vérifie si le mot de passe est correct"""
+    password = request.query.get('password', '')
+    if ADDON_PASSWORD and password == ADDON_PASSWORD:
+        logging.info(f"Password verification attempt successful")
+        return web.json_response({"success": True})
+    elif not ADDON_PASSWORD:
+        logging.info(f"No password required")
+        return web.json_response({"success": True, "message": "No password required"})
+    else:
+        logging.info(f"Password verification attempt failed")
+        return web.json_response({"success": False}, status=401)
 
 async def handle_configure(request):
     """
@@ -146,6 +162,10 @@ async def handle_configure(request):
         
         # Injection de la version de l'application
         content = content.replace('const appVersion = "1.1.0";', f'const appVersion = "{APP_VERSION}";')
+
+        # Injection de la protection par mot de passe
+        password_required_js = 'true' if ADDON_PASSWORD else 'false'
+        content = content.replace('const addonPasswordRequired = false;', f'const addonPasswordRequired = {password_required_js};')
         
         return web.Response(text=content, content_type='text/html')
     except Exception as e:
@@ -159,6 +179,17 @@ def decode_config(config_str):
         logging.error(f"Config Decode Error: {e}")
         return None
 
+def is_addon_password_valid(config):
+    """Vérifie si le mot de passe de l'addon est correct"""
+    if not ADDON_PASSWORD:
+        return True
+    
+    if not config or config.get('password') != ADDON_PASSWORD:
+        logging.warning(f"Unauthorized access attempt: Invalid or missing addon password")
+        return False
+        
+    return True
+
 async def handle_manifest(request):
     """Retourne le manifest de l'addon"""
     config_str = request.match_info.get('config', '')
@@ -166,6 +197,9 @@ async def handle_manifest(request):
     
     if not config:
         return web.Response(status=400, text="Invalid Config")
+    
+    if not is_addon_password_valid(config):
+        return web.Response(status=401, text="Unauthorized: Invalid Password")
 
     # Construction du nom de l'addon avec suffixe optionnel
     addon_name = "Frenchio"
@@ -246,6 +280,9 @@ async def handle_stream(request):
     config = decode_config(config_str)
     if not config:
         return web.json_response({"streams": []})
+
+    if not is_addon_password_valid(config):
+        return web.json_response({"streams": [], "message": "Unauthorized: Invalid Password"}, status=401)
 
     stream_type = request.match_info.get('type')
     stream_id = request.match_info.get('id')
@@ -812,6 +849,9 @@ async def handle_resolve(request):
     if not config:
         return web.Response(status=400, text="Invalid config")
     
+    if not is_addon_password_valid(config):
+        return web.Response(status=401, text="Unauthorized: Invalid Password")
+    
     service_name = request.match_info.get('service', 'alldebrid')
     info_hash = request.match_info.get('hash')
     
@@ -996,6 +1036,7 @@ async def get_app():
     app = web.Application(middlewares=[cors_middleware])
     app.router.add_get('/', handle_configure)
     app.router.add_get('/configure', handle_configure)
+    app.router.add_get('/verify-password', handle_verify_password)
     app.router.add_get('/manifest.json', handle_manifest_no_config)
     app.router.add_get('/stream/{type}/{id}.json', handle_stream_no_config)
     app.router.add_get('/{config}/', handle_configure) # Nouvelle route pour config pré-remplie

--- a/templates/configure.html
+++ b/templates/configure.html
@@ -470,7 +470,26 @@
             </p>
         </div>
 
-        <!-- Services Obligatoires -->
+        <!-- Section Mot de Passe (si activé sur le serveur) -->
+        <div id="passwordGateCard" class="card" style="display: none;">
+            <div class="card-header">
+                <h2>🔐 Mot de passe requis</h2>
+            </div>
+            <p class="help-text">
+                Cet addon est protégé par un mot de passe. Veuillez le saisir pour accéder à la configuration.
+            </p>
+            <div class="form-group" style="margin-top: 20px;">
+                <label for="addonPassword">Mot de passe de l'addon</label>
+                <div style="display: flex; gap: 10px;">
+                    <input type="password" id="addonPassword" placeholder="Saisissez le mot de passe..." style="flex: 1;">
+                    <button type="button" class="btn btn-primary" onclick="verifyPassword()" id="verifyPwBtn" style="width: auto; padding: 0 24px;">Vérifier</button>
+                </div>
+                <div id="pwMessage" style="margin-top: 10px; font-weight: 600; font-size: 0.875rem; display: none;"></div>
+            </div>
+        </div>
+
+        <div id="configContainer" style="display: none;">
+            <!-- Services Obligatoires -->
         <div class="card">
             <div class="card-header">
                 <h2>🔑 Services Requis</h2>
@@ -912,6 +931,7 @@
         <div style="text-align: center; margin-top: 40px;">
             <button type="button" class="btn btn-primary" onclick="generateLink()">🚀 Générer et Installer</button>
         </div>
+        </div>
 
         <div id="installLink">
             <h3>Configuration prête !</h3>
@@ -936,6 +956,7 @@
         const qbittorrentEnabled = true;
         const manifestBlurb = "";
         const appVersion = "1.1.0";
+        const addonPasswordRequired = false;
 
         function addTracker(data = null) {
             const container = document.getElementById('trackersContainer');
@@ -1009,6 +1030,23 @@
         });
 
         // Chargement initial
+        if (addonPasswordRequired) {
+            const gateCard = document.getElementById('passwordGateCard');
+            const container = document.getElementById('configContainer');
+            
+            gateCard.style.display = 'block';
+            container.style.display = 'none';
+            
+            if (prefillConfig && prefillConfig.password) {
+                document.getElementById('addonPassword').value = prefillConfig.password;
+                // Auto-verify prefilled password
+                verifyPassword(true);
+            }
+        } else {
+            // Show config if no password is required
+            document.getElementById('configContainer').style.display = 'block';
+        }
+
         if (prefillConfig && Object.keys(prefillConfig).length > 0) {
             document.getElementById('tmdbKey').value = prefillConfig.tmdb_key || '';
 
@@ -1132,6 +1170,53 @@
             handle: '.sortable-item'
         });
 
+        async function verifyPassword(auto = false) {
+            const password = document.getElementById('addonPassword').value;
+            const messageEl = document.getElementById('pwMessage');
+            const btn = document.getElementById('verifyPwBtn');
+            const container = document.getElementById('configContainer');
+            const gateCard = document.getElementById('passwordGateCard');
+
+            if (!password && !auto) return;
+
+            try {
+                const response = await fetch(`/verify-password?password=${encodeURIComponent(password)}`);
+                const result = await response.json();
+
+                if (result.success) {
+                    messageEl.style.color = 'var(--success)';
+                    messageEl.textContent = '✓ Mot de passe valide';
+                    messageEl.style.display = 'block';
+                    
+                    document.getElementById('addonPassword').disabled = true;
+                    btn.style.display = 'none';
+                    
+                    // Unlock the rest of the config
+                    container.style.display = 'block';
+                    
+                    // If it was manual (not auto), scroll to the content
+                    if (!auto) {
+                        setTimeout(() => {
+                            container.scrollIntoView({ behavior: 'smooth' });
+                        }, 100);
+                    }
+                } else {
+                    messageEl.style.color = 'var(--danger)';
+                    messageEl.textContent = '✗ Mot de passe incorrect';
+                    messageEl.style.display = 'block';
+                    container.style.display = 'none';
+                    if (auto) {
+                        gateCard.style.display = 'block'; // Show if auto-verify failed
+                    }
+                }
+            } catch (error) {
+                console.error('Erreur lors de la vérification du mot de passe:', error);
+                messageEl.style.color = 'var(--warning)';
+                messageEl.textContent = '⚠ Erreur de connexion au serveur';
+                messageEl.style.display = 'block';
+            }
+        }
+
         function generateLink() {
             const tmdbKey = document.getElementById('tmdbKey').value.trim();
 
@@ -1226,6 +1311,7 @@
                 .map(li => li.getAttribute('data-id'));
 
             const config = {
+                password: document.getElementById('addonPassword').value,
                 tmdb_key: tmdbKey,
                 alldebrid_key: alldebridKey,
                 torbox_key: torboxKey,


### PR DESCRIPTION
Salut Aymene, merci pour le projet. Pour pouvoir partager le lien avec des potes sur une URL publique sans pour autant que n'importe qui puisse l'utiliser, je me suis dit que ça pourrait être bien d'avoir du support pour un mot de passe.

If ADDON_PASSWORD is set in .env : 

- Config requires password input (using handle_verify_password). Automatically verifies and unlocks configuration when using "Edit Configuration" if the password is still correct.
- Manifest is generated with pw, which is saved to the config
- is_addon_password_valid is called upon requests to check whether a pw is needed and whether the right pw is included