### PR TITLE
feat: optional server-side default tracker and tmdb apis in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,23 @@ environment:
   - MANIFEST_BLURB=<b>Premium hosting by ElfHosted</b> - <a href="https://elfhosted.com/support">Support</a>
 ```
 
+### Valeurs par défaut (API Keys & Trackers)
+
+Frenchio permet aux administrateurs de définir des clés API par défaut. Si ces variables sont présentes dans le `.env` ou l'environnement Docker, les utilisateurs peuvent laisser les champs correspondants vides dans la page de configuration, et l'addon utilisera automatiquement les valeurs du serveur.
+
+| Variable | Description |
+| :--- | :--- |
+| `TMDB_KEY` | Clé API TMDB par défaut |
+| `SHAREWOOD_PASSKEY` | Passkey Sharewood par défaut |
+| `ABN_USERNAME` / `ABN_PASSWORD` | Identifiants ABN par défaut |
+| `LACALE_APIKEY` | Clé API La-Cale par défaut |
+| `C411_APIKEY` | Clé API C411 par défaut |
+| `TORR9_PASSKEY` | Passkey Torr9 par défaut |
+
+> [!IMPORTANT]
+> **Sécurité renforcée** : Contrairement aux clés saisies manuellement, ces valeurs par défaut restent **exclusivement sur le serveur**. Elles ne sont **pas** incluses dans l'URL de configuration générée, garantissant une confidentialité totale pour l'administrateur.
+```
+
 ## 🔧 Configuration qBittorrent
 
 Pour un streaming optimal avec qBittorrent :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,13 @@ services:
       # - MANIFEST_TITLE_SUFFIX=| ElfHosted
       # Optional: Add custom HTML/markup blurb to manifest description
       # - MANIFEST_BLURB=<b>Custom message here</b>
+      # - TMDB_KEY=
+      # - SHAREWOOD_PASSKEY=
+      # - ABN_USERNAME=
+      # - ABN_PASSWORD=
+      # - LACALE_APIKEY=
+      # - C411_APIKEY=
+      # - TORR9_PASSKEY=
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:7777/manifest.json')"]

--- a/main.py
+++ b/main.py
@@ -73,20 +73,20 @@ QBITTORRENT_ENABLE = os.getenv('QBITTORRENT_ENABLE', 'true').lower() in ('true',
 MANIFEST_TITLE_SUFFIX = os.getenv('MANIFEST_TITLE_SUFFIX', '')
 MANIFEST_BLURB = os.getenv('MANIFEST_BLURB', '')
 
-# Valeurs par défaut du serveur (.env)
-DEFAULT_TMDB_KEY = os.getenv('TMDB_KEY')
-DEFAULT_SHAREWOOD_PASSKEY = os.getenv('SHAREWOOD_PASSKEY')
-DEFAULT_ABN_USERNAME = os.getenv('ABN_USERNAME')
-DEFAULT_ABN_PASSWORD = os.getenv('ABN_PASSWORD')
-DEFAULT_LACALE_APIKEY = os.getenv('LACALE_APIKEY') or os.getenv('LACALE_PASSKEY')
-DEFAULT_C411_APIKEY = os.getenv('C411_APIKEY')
-DEFAULT_TORR9_PASSKEY = os.getenv('TORR9_PASSKEY')
+# Configuration des valeurs par défaut du serveur (.env)
+SERVER_CONFIG_DEFAULTS = [
+    {'keys': ['tmdb_key'], 'values': [DEFAULT_TMDB_KEY], 'label': 'TMDB', 'ui_field': 'tmdb_key'},
+    {'keys': ['sharewood_passkey'], 'values': [DEFAULT_SHAREWOOD_PASSKEY], 'label': 'Sharewood', 'ui_field': 'sharewood_passkey'},
+    {'keys': ['abn_username', 'abn_password'], 'values': [DEFAULT_ABN_USERNAME, DEFAULT_ABN_PASSWORD], 'label': 'ABN', 'ui_field': 'abn'},
+    {'keys': ['lacale_apikey'], 'values': [DEFAULT_LACALE_APIKEY], 'label': 'LaCale', 'ui_field': 'lacale_apikey'},
+    {'keys': ['c411_apikey'], 'values': [DEFAULT_C411_APIKEY], 'label': 'C411', 'ui_field': 'c411_apikey'},
+    {'keys': ['torr9_passkey'], 'values': [DEFAULT_TORR9_PASSKEY], 'label': 'Torr9', 'ui_field': 'torr9_passkey'},
+]
 
-logging.info(f"qBittorrent enabled: {QBITTORRENT_ENABLE}")
-if MANIFEST_TITLE_SUFFIX:
-    logging.info(f"Manifest title suffix: {MANIFEST_TITLE_SUFFIX}")
-if MANIFEST_BLURB:
-    logging.info(f"Manifest blurb configured")
+# Logging des valeurs par défaut actives
+defaults_active = [d['label'] for d in SERVER_CONFIG_DEFAULTS if all(d['values'])]
+if defaults_active:
+    logging.info(f"Server-side defaults active: {', '.join(defaults_active)}")
 
 # ============================================================================
 # Middleware
@@ -150,13 +150,7 @@ async def handle_configure(request):
         content = content.replace('const qbittorrentEnabled = true;', f'const qbittorrentEnabled = {qbit_enabled_js};')
         
         # Signalisation des champs ayant des valeurs par défaut sur le serveur (noms seulement)
-        server_config_fields = []
-        if DEFAULT_TMDB_KEY: server_config_fields.append('tmdb_key')
-        if DEFAULT_SHAREWOOD_PASSKEY: server_config_fields.append('sharewood_passkey')
-        if DEFAULT_ABN_USERNAME and DEFAULT_ABN_PASSWORD: server_config_fields.append('abn')
-        if DEFAULT_LACALE_APIKEY: server_config_fields.append('lacale_apikey')
-        if DEFAULT_C411_APIKEY: server_config_fields.append('c411_apikey')
-        if DEFAULT_TORR9_PASSKEY: server_config_fields.append('torr9_passkey')
+        server_config_fields = [d['ui_field'] for d in SERVER_CONFIG_DEFAULTS if all(d['values'])]
         
         content = content.replace('const serverConfigFields = [];', f'const serverConfigFields = {json.dumps(server_config_fields)};')
         
@@ -173,30 +167,15 @@ async def handle_configure(request):
 
 def decode_config(config_str):
     try:
-        decoded_str = base64.b64decode(config_str).decode('utf-8')
-        config = json.loads(decoded_str)
+        decoded = base64.b64decode(config_str).decode('utf-8')
+        config = json.loads(decoded)
         
-        # --- Injection chirurgicale des défauts du serveur ---
         # Si une clé est absente ou vide dans la config utilisateur, on injecte la valeur .env
-        if not config.get('tmdb_key') and DEFAULT_TMDB_KEY:
-            config['tmdb_key'] = DEFAULT_TMDB_KEY
-            
-        if not config.get('sharewood_passkey') and DEFAULT_SHAREWOOD_PASSKEY:
-            config['sharewood_passkey'] = DEFAULT_SHAREWOOD_PASSKEY
-            
-        if not config.get('abn_username') and DEFAULT_ABN_USERNAME:
-            config['abn_username'] = DEFAULT_ABN_USERNAME
-        if not config.get('abn_password') and DEFAULT_ABN_PASSWORD:
-            config['abn_password'] = DEFAULT_ABN_PASSWORD
-            
-        if not config.get('lacale_apikey') and DEFAULT_LACALE_APIKEY:
-            config['lacale_apikey'] = DEFAULT_LACALE_APIKEY
-            
-        if not config.get('c411_apikey') and DEFAULT_C411_APIKEY:
-            config['c411_apikey'] = DEFAULT_C411_APIKEY
-            
-        if not config.get('torr9_passkey') and DEFAULT_TORR9_PASSKEY:
-            config['torr9_passkey'] = DEFAULT_TORR9_PASSKEY
+        for d in SERVER_CONFIG_DEFAULTS:
+            if all(d['values']):
+                for key, val in zip(d['keys'], d['values']):
+                    if not config.get(key):
+                        config[key] = val
             
         return config
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ if MANIFEST_BLURB:
     logging.info(f"Manifest blurb configured")
 defaults_active = [d['label'] for d in SERVER_CONFIG_DEFAULTS if all(d['values'])]
 if defaults_active:
-    logging.info(f"Server-side default trackers: {', '.join(defaults_active)}")
+    logging.info(f"Server-side default keys: {', '.join(defaults_active)}")
 
 # ============================================================================
 # Middleware

--- a/main.py
+++ b/main.py
@@ -73,6 +73,15 @@ QBITTORRENT_ENABLE = os.getenv('QBITTORRENT_ENABLE', 'true').lower() in ('true',
 MANIFEST_TITLE_SUFFIX = os.getenv('MANIFEST_TITLE_SUFFIX', '')
 MANIFEST_BLURB = os.getenv('MANIFEST_BLURB', '')
 
+# Valeurs par défaut du serveur (.env)
+DEFAULT_TMDB_KEY = os.getenv('TMDB_KEY')
+DEFAULT_SHAREWOOD_PASSKEY = os.getenv('SHAREWOOD_PASSKEY')
+DEFAULT_ABN_USERNAME = os.getenv('ABN_USERNAME')
+DEFAULT_ABN_PASSWORD = os.getenv('ABN_PASSWORD')
+DEFAULT_LACALE_APIKEY = os.getenv('LACALE_APIKEY') or os.getenv('LACALE_PASSKEY')
+DEFAULT_C411_APIKEY = os.getenv('C411_APIKEY')
+DEFAULT_TORR9_PASSKEY = os.getenv('TORR9_PASSKEY')
+
 logging.info(f"qBittorrent enabled: {QBITTORRENT_ENABLE}")
 if MANIFEST_TITLE_SUFFIX:
     logging.info(f"Manifest title suffix: {MANIFEST_TITLE_SUFFIX}")
@@ -140,6 +149,17 @@ async def handle_configure(request):
         qbit_enabled_js = 'true' if QBITTORRENT_ENABLE else 'false'
         content = content.replace('const qbittorrentEnabled = true;', f'const qbittorrentEnabled = {qbit_enabled_js};')
         
+        # Signalisation des champs ayant des valeurs par défaut sur le serveur (noms seulement)
+        server_config_fields = []
+        if DEFAULT_TMDB_KEY: server_config_fields.append('tmdb_key')
+        if DEFAULT_SHAREWOOD_PASSKEY: server_config_fields.append('sharewood_passkey')
+        if DEFAULT_ABN_USERNAME and DEFAULT_ABN_PASSWORD: server_config_fields.append('abn')
+        if DEFAULT_LACALE_APIKEY: server_config_fields.append('lacale_apikey')
+        if DEFAULT_C411_APIKEY: server_config_fields.append('c411_apikey')
+        if DEFAULT_TORR9_PASSKEY: server_config_fields.append('torr9_passkey')
+        
+        content = content.replace('const serverConfigFields = [];', f'const serverConfigFields = {json.dumps(server_config_fields)};')
+        
         # Injection du blurb personnalisé (échappé pour JavaScript)
         blurb_escaped = json.dumps(MANIFEST_BLURB) if MANIFEST_BLURB else '""'
         content = content.replace('const manifestBlurb = "";', f'const manifestBlurb = {blurb_escaped};')
@@ -153,8 +173,32 @@ async def handle_configure(request):
 
 def decode_config(config_str):
     try:
-        decoded = base64.b64decode(config_str).decode('utf-8')
-        return json.loads(decoded)
+        decoded_str = base64.b64decode(config_str).decode('utf-8')
+        config = json.loads(decoded_str)
+        
+        # --- Injection chirurgicale des défauts du serveur ---
+        # Si une clé est absente ou vide dans la config utilisateur, on injecte la valeur .env
+        if not config.get('tmdb_key') and DEFAULT_TMDB_KEY:
+            config['tmdb_key'] = DEFAULT_TMDB_KEY
+            
+        if not config.get('sharewood_passkey') and DEFAULT_SHAREWOOD_PASSKEY:
+            config['sharewood_passkey'] = DEFAULT_SHAREWOOD_PASSKEY
+            
+        if not config.get('abn_username') and DEFAULT_ABN_USERNAME:
+            config['abn_username'] = DEFAULT_ABN_USERNAME
+        if not config.get('abn_password') and DEFAULT_ABN_PASSWORD:
+            config['abn_password'] = DEFAULT_ABN_PASSWORD
+            
+        if not config.get('lacale_apikey') and DEFAULT_LACALE_APIKEY:
+            config['lacale_apikey'] = DEFAULT_LACALE_APIKEY
+            
+        if not config.get('c411_apikey') and DEFAULT_C411_APIKEY:
+            config['c411_apikey'] = DEFAULT_C411_APIKEY
+            
+        if not config.get('torr9_passkey') and DEFAULT_TORR9_PASSKEY:
+            config['torr9_passkey'] = DEFAULT_TORR9_PASSKEY
+            
+        return config
     except Exception as e:
         logging.error(f"Config Decode Error: {e}")
         return None

--- a/main.py
+++ b/main.py
@@ -74,6 +74,14 @@ MANIFEST_TITLE_SUFFIX = os.getenv('MANIFEST_TITLE_SUFFIX', '')
 MANIFEST_BLURB = os.getenv('MANIFEST_BLURB', '')
 
 # Configuration des valeurs par défaut du serveur (.env)
+DEFAULT_TMDB_KEY = os.getenv('TMDB_KEY')
+DEFAULT_SHAREWOOD_PASSKEY = os.getenv('SHAREWOOD_PASSKEY')
+DEFAULT_ABN_USERNAME = os.getenv('ABN_USERNAME')
+DEFAULT_ABN_PASSWORD = os.getenv('ABN_PASSWORD')
+DEFAULT_LACALE_APIKEY = os.getenv('LACALE_APIKEY') or os.getenv('LACALE_PASSKEY')
+DEFAULT_C411_APIKEY = os.getenv('C411_APIKEY')
+DEFAULT_TORR9_PASSKEY = os.getenv('TORR9_PASSKEY')
+
 SERVER_CONFIG_DEFAULTS = [
     {'keys': ['tmdb_key'], 'values': [DEFAULT_TMDB_KEY], 'label': 'TMDB', 'ui_field': 'tmdb_key'},
     {'keys': ['sharewood_passkey'], 'values': [DEFAULT_SHAREWOOD_PASSKEY], 'label': 'Sharewood', 'ui_field': 'sharewood_passkey'},
@@ -84,9 +92,14 @@ SERVER_CONFIG_DEFAULTS = [
 ]
 
 # Logging des valeurs par défaut actives
+logging.info(f"qBittorrent enabled: {QBITTORRENT_ENABLE}")
+if MANIFEST_TITLE_SUFFIX:
+    logging.info(f"Manifest title suffix: {MANIFEST_TITLE_SUFFIX}")
+if MANIFEST_BLURB:
+    logging.info(f"Manifest blurb configured")
 defaults_active = [d['label'] for d in SERVER_CONFIG_DEFAULTS if all(d['values'])]
 if defaults_active:
-    logging.info(f"Server-side defaults active: {', '.join(defaults_active)}")
+    logging.info(f"Server-side default trackers: {', '.join(defaults_active)}")
 
 # ============================================================================
 # Middleware
@@ -149,7 +162,7 @@ async def handle_configure(request):
         qbit_enabled_js = 'true' if QBITTORRENT_ENABLE else 'false'
         content = content.replace('const qbittorrentEnabled = true;', f'const qbittorrentEnabled = {qbit_enabled_js};')
         
-        # Signalisation des champs ayant des valeurs par défaut sur le serveur (noms seulement)
+        # Trackers ayant des valeurs par défaut sur le serveur
         server_config_fields = [d['ui_field'] for d in SERVER_CONFIG_DEFAULTS if all(d['values'])]
         
         content = content.replace('const serverConfigFields = [];', f'const serverConfigFields = {json.dumps(server_config_fields)};')

--- a/templates/configure.html
+++ b/templates/configure.html
@@ -207,6 +207,14 @@
             text-decoration: underline;
         }
 
+        .help-text.server-default {
+            color: var(--success);
+            font-weight: 500;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
         input[type="text"],
         input[type="url"],
         input[type="password"],
@@ -936,6 +944,7 @@
         const qbittorrentEnabled = true;
         const manifestBlurb = "";
         const appVersion = "1.1.0";
+        const serverConfigFields = [];
 
         function addTracker(data = null) {
             const container = document.getElementById('trackersContainer');
@@ -1131,6 +1140,57 @@
             ghostClass: 'sortable-ghost',
             handle: '.sortable-item'
         });
+
+        // Appliquer les indicateurs de défauts serveur sur les placeholders
+        function applyServerDefaultsUI() {
+            if (!serverConfigFields || serverConfigFields.length === 0) return;
+
+            const fieldMap = {
+                'tmdb_key': 'tmdbKey',
+                'sharewood_passkey': 'sharewoodPasskey',
+                'abn': 'abnUsername',
+                'lacale_apikey': 'lacaleApikey',
+                'c411_apikey': 'c411Apikey',
+                'torr9_passkey': 'torr9Passkey'
+            };
+
+            const cardMap = {
+                'sharewood_passkey': 'providerSharewood',
+                'abn': 'providerAbn',
+                'lacale_apikey': 'providerLacale',
+                'c411_apikey': 'providerC411',
+                'torr9_passkey': 'providerTorr9'
+            };
+
+            serverConfigFields.forEach(field => {
+                const inputId = fieldMap[field];
+                const input = document.getElementById(inputId);
+                if (input) {
+                    const help = document.createElement('span');
+                    help.className = 'help-text server-default';
+                    help.innerHTML = '💡 Laissez vide pour utiliser la valeur par défaut du serveur';
+                    input.parentNode.appendChild(help);
+                }
+
+                // Ajouter le badge "ACTIF" sur la carte du provider
+                const cardId = cardMap[field];
+                if (cardId) {
+                    const card = document.getElementById(cardId);
+                    if (card) {
+                        card.classList.add('active'); // Allume le point vert
+                        const nameSpan = card.querySelector('.provider-name');
+                        if (nameSpan && !nameSpan.querySelector('.provider-badge')) {
+                            const badge = document.createElement('span');
+                            badge.className = 'provider-badge always-on';
+                            badge.style.marginLeft = '8px';
+                            badge.textContent = 'ACTIF';
+                            nameSpan.appendChild(badge);
+                        }
+                    }
+                }
+            });
+        }
+        applyServerDefaultsUI();
 
         function generateLink() {
             const tmdbKey = document.getElementById('tmdbKey').value.trim();

--- a/templates/configure.html
+++ b/templates/configure.html
@@ -1246,7 +1246,7 @@
             const maxSize = parseInt(document.getElementById('maxSize').value) || 0;
             const sortBy = document.getElementById('sortBy').value;
 
-            if (!tmdbKey) {
+            if (!tmdbKey && !serverConfigFields.includes('tmdb_key')) {
                 alert("Erreur : La clé TMDB est obligatoire.");
                 return;
             }


### PR DESCRIPTION
Added : TMDB_KEY, SHAREWOOD_PASSKEY,  ABN_USERNAME & ABN_PASSWORD, LACALE_APIKEY, C411_APIKEY, TORR9_PASSKEY as configurable .env variables

This allows server-side defaults, meant mostly for "semi-private" instances.

To make sure there is no leakage of keys even in the URLs, it all happens in the backend.
The encoded config is generated without keys when the user leaves empty strings.
Upon config decoding following a requests (decode_config), SERVER_CONFIG_DEFAULTS are added to the decoded config.

Hints are left for the user in the frontend and configured keys get the "ACTIF" tag