### PR TITLE
feat: variable STREMTHRU_URL pour StremThru auto-hébergé

### DIFF
--- a/services/realdebrid.py
+++ b/services/realdebrid.py
@@ -1,6 +1,7 @@
 import aiohttp
 import logging
 import asyncio
+import os
 
 
 class RealDebridService:
@@ -10,7 +11,7 @@ class RealDebridService:
     avec un endpoint check_magnets en batch (pas de rate-limit).
     """
 
-    STREMTHRU_URL = "https://stremthru.13377001.xyz"
+    STREMTHRU_URL = os.getenv("STREMTHRU_URL", "https://stremthru.13377001.xyz")
 
     def __init__(self, api_key):
         self.api_key = api_key


### PR DESCRIPTION
Ajoute la possibilité de surcharger l'URL StremThru via la variable
d'environnement `STREMTHRU_URL`, en gardant l'instance publique actuelle
comme valeur par défaut.

Aucun changement de comportement pour les utilisateurs de l'instance
partagée — la valeur par défaut reste `https://stremthru.13377001.xyz`.

Utile pour les self-hosters qui font tourner leur propre StremThru à
côté de Frenchio (ex. `STREMTHRU_URL=http://stremthru:8080`).

Note : ce n'est pas une clé / credential — StremThru continue à utiliser
les en-têtes `X-StremThru-Store-Authorization` par appel, donc rien n'est
mutualisé entre utilisateurs. Aucun risque de fuite ou de partage de
clés sur une instance multi-utilisateurs.

Suit la convention `os.getenv(..., default)` déjà utilisée dans `main.py`
pour `HTTP_PROXY`, `QBITTORRENT_ENABLE`, `MANIFEST_TITLE_SUFFIX`, etc.

Diff : 2 lignes (un `import os`, une ligne modifiée).