### PR TITLE
Nyaa & NekoBT pour les animes : numérotation absolue, OVA, fix rate-limit (étend #18)

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,6 +40,8 @@ from services.c411 import C411Service
 from services.torr9 import Torr9Service
 from services.qbittorrent import QBittorrentService
 from services.tr4ker import Tr4kerService
+from services.nyaa import NyaaService
+from services.nekobt import NekoBTService
 from utils import format_size, parse_torrent_name, check_season_episode, check_title_match, is_video_file
 
 # Configuration du logging
@@ -407,9 +409,23 @@ async def handle_stream(request):
     target_title = (media_info.get('title') or media_info.get('name')) if media_info else ""
     original_title = (media_info.get('original_title') or media_info.get('original_name')) if media_info else ""
     year = ""
+    is_anime = False
     if media_info:
         date = media_info.get('release_date') or media_info.get('first_air_date')
         year = date.split('-')[0] if date else ""
+        
+        orig_lang = media_info.get('original_language', '')
+        origin_country = media_info.get('origin_country', [])
+        genres = media_info.get('genres', [])
+        genre_ids = [g.get('id') for g in genres] if genres else media_info.get('genre_ids', [])
+        
+        if orig_lang in ['ja', 'ko', 'zh'] or 'JP' in origin_country:
+            if 16 in genre_ids or orig_lang == 'ja':
+                is_anime = True
+                
+        # Fallback pour les animes très spécifiques qui pourraient manquer d'infos complètes
+        if 'anime' in (media_info.get('overview') or '').lower() and 16 in genre_ids:
+            is_anime = True
 
     if stream_type == 'movie':
         tasks.append(ygg_service.search_movie(target_title, year, original_title=original_title, imdb_id=imdb_id, tmdb_id=tmdb_id))
@@ -479,6 +495,36 @@ async def handle_stream(request):
         async def empty(): return []
         tasks.append(empty())
 
+    # Tâche NekoBT
+    if config.get('neko_apikey') and is_anime:
+        logging.info("Starting NekoBT search")
+        nekobt_service = NekoBTService(config.get('neko_apikey'))
+
+        if stream_type == 'movie':
+            tasks.append(nekobt_service.search_movie(target_title, year, imdb_id=imdb_id, tmdb_id=tmdb_id))
+        elif stream_type == 'series':
+            tasks.append(nekobt_service.search_series(target_title, season, episode, imdb_id=imdb_id, tmdb_id=tmdb_id))
+    else:
+        if config.get('neko_apikey') and not is_anime:
+            logging.info("NekoBT search skipped (Not an anime)")
+        async def empty(): return []
+        tasks.append(empty())
+
+    # Tâche Nyaa
+    if config.get('nyaa_enabled') and is_anime:
+        logging.info("Starting Nyaa search")
+        nyaa_service = NyaaService()
+
+        if stream_type == 'movie':
+            tasks.append(nyaa_service.search_movie(target_title, year, imdb_id=imdb_id, tmdb_id=tmdb_id))
+        elif stream_type == 'series':
+            tasks.append(nyaa_service.search_series(target_title, season, episode, imdb_id=imdb_id, tmdb_id=tmdb_id))
+    else:
+        if config.get('nyaa_enabled') and not is_anime:
+            logging.info("Nyaa search skipped (Not an anime)")
+        async def empty(): return []
+        tasks.append(empty())
+
     # Exécution
     try:
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
@@ -498,15 +544,28 @@ async def handle_stream(request):
         c411_results = safe(3)
         torr9_results = safe(4)
         tr4ker_results = safe(5)
+        nekobt_results = safe(6)
+        nyaa_results = safe(7)
     finally:
         # Fermer la session ABN proprement
         if abn_service:
             await abn_service.close()
 
-    logging.info(f"Results breakdown: UNIT3D={len(unit3d_results)}, YGG={len(ygg_results)}, ABN={len(abn_results)}, C411={len(c411_results)}, Torr9={len(torr9_results)}, Tr4ker={len(tr4ker_results)}")
+    logging.info(f"Results breakdown: UNIT3D={len(unit3d_results)}, YGG={len(ygg_results)}, ABN={len(abn_results)}, C411={len(c411_results)}, Torr9={len(torr9_results)}, Tr4ker={len(tr4ker_results)}, NekoBT={len(nekobt_results)}, Nyaa={len(nyaa_results)}")
 
     # Fusion et Déduplication
-    all_torrents = unit3d_results + ygg_results + abn_results + c411_results + torr9_results + tr4ker_results
+    all_torrents = unit3d_results + ygg_results + abn_results + c411_results + torr9_results + tr4ker_results + nekobt_results + nyaa_results
+    
+    # Tri préalable selon providers_order pour que le tracker favori soit gardé lors de la déduplication
+    providers_order = config.get('providers_order', [])
+    if providers_order:
+        def get_prov_sort_key(t):
+            source = t.get('source', '')
+            try:
+                return providers_order.index(source)
+            except ValueError:
+                return len(providers_order)
+        all_torrents.sort(key=get_prov_sort_key)
     
     # Filtrage par taille si configuré
     max_size_gb = config.get('max_size', 0)
@@ -558,15 +617,18 @@ async def handle_stream(request):
 
         # Filtrage par titre et année (Vérification systématique pour éviter les erreurs de mapping des trackers)
         if stream_type in ('movie', 'series'):
-            if not check_title_match(t.get('name', ''), target_title, original_title, year=year, is_movie=(stream_type == 'movie')):
-                # logging.info(f"Filtered out (Title mismatch): {t.get('name')} for target {target_title}")
-                continue
+            # Pour l'animation (Nyaa/NekoBT), le nommage est trop complexe (ex: sous-titres anglais) pour le filtre strict
+            if t.get('source') not in ('nyaa', 'nekobt'):
+                if not check_title_match(t.get('name', ''), target_title, original_title, year=year, is_movie=(stream_type == 'movie')):
+                    # logging.info(f"Filtered out (Title mismatch): {t.get('name')} for target {target_title}")
+                    continue
 
         # Filtrage Série (SxxExx)
         # Si c'est une série, on vérifie que le titre correspond à la saison/épisode demandé
         # pour éviter d'afficher E03 quand on veut E07 (souvent le cas avec recherche floue)
         if stream_type == 'series' and season is not None:
-            if not check_season_episode(t.get('name', ''), season, episode):
+            exclude_packs = config.get('exclude_season_packs', False)
+            if not check_season_episode(t.get('name', ''), season, episode, exclude_packs=exclude_packs):
                 # logging.info(f"Filtered out: {t.get('name')} (Wrong Season/Episode)")
                 continue
 
@@ -586,7 +648,7 @@ async def handle_stream(request):
     if not torrents:
         return web.json_response({"streams": []})
 
-    logging.info(f"Total unique torrents (UNIT3D + YGG + ABN + C411 + Torr9 + Tr4ker): {len(torrents)}")
+    logging.info(f"Total unique torrents (UNIT3D + YGG + ABN + C411 + Torr9 + Tr4ker + NekoBT + Nyaa): {len(torrents)}")
 
     streams = []
     host_url = f"{request.scheme}://{request.host}"

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ from services.qbittorrent import QBittorrentService
 from services.tr4ker import Tr4kerService
 from services.nyaa import NyaaService
 from services.nekobt import NekoBTService
-from utils import format_size, parse_torrent_name, check_season_episode, check_absolute_episode, check_title_match, is_video_file
+from utils import format_size, parse_torrent_name, check_season_episode, check_absolute_episode, check_special_episode, check_title_tokens, check_title_match, is_video_file
 
 # Configuration du logging
 logging.basicConfig(
@@ -641,11 +641,23 @@ async def handle_stream(request):
         # pour éviter d'afficher E03 quand on veut E07 (souvent le cas avec recherche floue)
         if stream_type == 'series' and season is not None:
             exclude_packs = config.get('exclude_season_packs', False)
-            if not check_season_episode(t.get('name', ''), season, episode, exclude_packs=exclude_packs):
-                # Nommage anime en numérotation absolue (Nyaa/NekoBT uniquement)
-                if not (t.get('source') in ('nyaa', 'nekobt') and check_absolute_episode(t.get('name', ''), absolute_episode, exclude_packs=exclude_packs)):
-                    # logging.info(f"Filtered out: {t.get('name')} (Wrong Season/Episode)")
-                    continue
+            t_name = t.get('name', '')
+            is_anime_source = t.get('source') in ('nyaa', 'nekobt')
+            if season == 0 and is_anime_source:
+                # OVA/Spéciaux : nommage fansub ("Titre OVA 06") plutôt que S00Exx
+                se_ok = check_special_episode(t_name, episode, exclude_packs=exclude_packs)
+            else:
+                se_ok = check_season_episode(t_name, season, episode, exclude_packs=exclude_packs)
+                if not se_ok and is_anime_source:
+                    # Nommage anime en numérotation absolue (Nyaa/NekoBT uniquement)
+                    se_ok = check_absolute_episode(t_name, absolute_episode, exclude_packs=exclude_packs)
+            # Les acceptations "molles" (pack, range, absolu) sans match SxxExx exact
+            # doivent au moins contenir le titre pour écarter les hors-sujet
+            if se_ok and is_anime_source and not check_season_episode(t_name, season, episode, exclude_packs=True):
+                se_ok = check_title_tokens(t_name, target_title, original_title)
+            if not se_ok:
+                # logging.info(f"Filtered out: {t.get('name')} (Wrong Season/Episode)")
+                continue
 
         # Info Hash est la clé unique (minuscule pour éviter les doublons de casse)
         ih = t.get('info_hash')

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ from services.qbittorrent import QBittorrentService
 from services.tr4ker import Tr4kerService
 from services.nyaa import NyaaService
 from services.nekobt import NekoBTService
-from utils import format_size, parse_torrent_name, check_season_episode, check_title_match, is_video_file
+from utils import format_size, parse_torrent_name, check_season_episode, check_absolute_episode, check_title_match, is_video_file
 
 # Configuration du logging
 logging.basicConfig(
@@ -427,6 +427,19 @@ async def handle_stream(request):
         if 'anime' in (media_info.get('overview') or '').lower() and 16 in genre_ids:
             is_anime = True
 
+    # Numérotation absolue des épisodes (nommage fansub anime : "One Piece S01E1122")
+    # Calculée depuis le découpage des saisons TMDB déjà présent dans media_info
+    absolute_episode = None
+    if is_anime and stream_type == 'series' and season and episode and media_info:
+        if season == 1:
+            absolute_episode = episode
+        else:
+            prev_seasons = [s for s in media_info.get('seasons', [])
+                            if s.get('season_number') and 0 < s['season_number'] < season]
+            if len(prev_seasons) == season - 1 and all(s.get('episode_count') for s in prev_seasons):
+                absolute_episode = sum(s['episode_count'] for s in prev_seasons) + episode
+                logging.info(f"Anime: épisode absolu calculé S{season:02d}E{episode:02d} -> {absolute_episode}")
+
     if stream_type == 'movie':
         tasks.append(ygg_service.search_movie(target_title, year, original_title=original_title, imdb_id=imdb_id, tmdb_id=tmdb_id))
     elif stream_type == 'series':
@@ -503,7 +516,7 @@ async def handle_stream(request):
         if stream_type == 'movie':
             tasks.append(nekobt_service.search_movie(target_title, year, imdb_id=imdb_id, tmdb_id=tmdb_id))
         elif stream_type == 'series':
-            tasks.append(nekobt_service.search_series(target_title, season, episode, imdb_id=imdb_id, tmdb_id=tmdb_id))
+            tasks.append(nekobt_service.search_series(target_title, season, episode, imdb_id=imdb_id, tmdb_id=tmdb_id, absolute_episode=absolute_episode))
     else:
         if config.get('neko_apikey') and not is_anime:
             logging.info("NekoBT search skipped (Not an anime)")
@@ -518,7 +531,7 @@ async def handle_stream(request):
         if stream_type == 'movie':
             tasks.append(nyaa_service.search_movie(target_title, year, imdb_id=imdb_id, tmdb_id=tmdb_id))
         elif stream_type == 'series':
-            tasks.append(nyaa_service.search_series(target_title, season, episode, imdb_id=imdb_id, tmdb_id=tmdb_id))
+            tasks.append(nyaa_service.search_series(target_title, season, episode, imdb_id=imdb_id, tmdb_id=tmdb_id, absolute_episode=absolute_episode))
     else:
         if config.get('nyaa_enabled') and not is_anime:
             logging.info("Nyaa search skipped (Not an anime)")
@@ -629,8 +642,10 @@ async def handle_stream(request):
         if stream_type == 'series' and season is not None:
             exclude_packs = config.get('exclude_season_packs', False)
             if not check_season_episode(t.get('name', ''), season, episode, exclude_packs=exclude_packs):
-                # logging.info(f"Filtered out: {t.get('name')} (Wrong Season/Episode)")
-                continue
+                # Nommage anime en numérotation absolue (Nyaa/NekoBT uniquement)
+                if not (t.get('source') in ('nyaa', 'nekobt') and check_absolute_episode(t.get('name', ''), absolute_episode, exclude_packs=exclude_packs)):
+                    # logging.info(f"Filtered out: {t.get('name')} (Wrong Season/Episode)")
+                    continue
 
         # Info Hash est la clé unique (minuscule pour éviter les doublons de casse)
         ih = t.get('info_hash')

--- a/services/nekobt.py
+++ b/services/nekobt.py
@@ -1,0 +1,141 @@
+import aiohttp
+import logging
+import urllib.parse
+import xml.etree.ElementTree as ET
+import re
+
+class NekoBTService:
+    def __init__(self, apikey):
+        self.apikey = apikey
+        self.base_url = "https://nekobt.to/api/torznab/api"
+
+    async def search(self, params):
+        if not self.apikey:
+            return []
+
+        params['apikey'] = self.apikey
+        params['cat'] = '5070'  # Anime category for NekoBT
+        params['t'] = 'search'  # Force generic search since NekoBT doesn't handle tmdbid well
+        
+        # Log request (masking apikey)
+        log_params = params.copy()
+        log_params['apikey'] = '***APIKEY***'
+        logging.info(f"NekoBT Search: {self.base_url}?{urllib.parse.urlencode(log_params)}")
+
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            try:
+                async with session.get(self.base_url, params=params, timeout=20) as response:
+                    if response.status == 200:
+                        text = await response.text()
+                        
+                        try:
+                            root = ET.fromstring(text)
+                        except ET.ParseError as e:
+                            logging.error(f"NekoBT XML Parse Error: {e}")
+                            return []
+
+                        items = root.findall('.//item')
+                        logging.info(f"NekoBT found {len(items)} results")
+                        
+                        normalized = []
+                        for res in items:
+                            title = res.findtext('title')
+                            description = res.findtext('description', default='')
+                            
+                            # Filtre strict FR : on rejette tout ce qui n'a pas de tag FR/VF/VOSTFR dans le titre ou la description
+                            title_upper = (title or "").upper()
+                            desc_upper = description.upper()
+                            
+                            has_fr_in_title = any(kw in title_upper for kw in ["FRENCH", "VOSTFR", "SUBFRENCH", "TRUEFRENCH", "VFF", "VF2", "VFQ"]) or re.search(r'\bVF\b', title_upper) or re.search(r'\bFR\b', title_upper)
+                            has_fr_in_desc = any(kw in desc_upper for kw in ["FRENCH", "FRANCAIS", "FRANÇAIS", "VOSTFR"]) or re.search(r'\bVF\b', desc_upper) or re.search(r'\bFR\b', desc_upper)
+                            
+                            if not has_fr_in_title and not has_fr_in_desc:
+                                continue # Skip this result as it has no French/VOSTFR
+                                
+                            torznab_ns = {'torznab': 'http://torznab.com/schemas/2015/feed'}
+                            
+                            info_hash = None
+                            seeders = 0
+                            leechers = 0
+                            size = int(res.findtext('size', default='0'))
+                            
+                            for attr in res.findall('torznab:attr', namespaces=torznab_ns):
+                                name = attr.get('name')
+                                value = attr.get('value')
+                                
+                                if name == 'infohash':
+                                    info_hash = value
+                                elif name == 'seeders':
+                                    seeders = int(value) if value else 0
+                                elif name == 'peers':
+                                    leechers = int(value) if value else 0
+                                elif name == 'size' and size == 0:
+                                    size = int(value) if value else 0
+                            
+                            # Fallback si infohash introuvable
+                            if not info_hash:
+                                guid = res.findtext('guid')
+                                if guid and len(guid) >= 40: # Extrait l'infohash d'une string si c'est un magnet ou un hash brut
+                                    match = re.search(r'([a-fA-F0-9]{40})', guid)
+                                    if match:
+                                        info_hash = match.group(1)
+
+                            if not info_hash:
+                                continue
+
+                            enclosure = res.find('enclosure')
+                            download_link = enclosure.get('url') if enclosure is not None else None
+                            if not download_link:
+                                download_link = res.findtext('link')
+
+                            item = {
+                                "name": title,
+                                "size": size,
+                                "tracker_name": "NekoBT",
+                                "info_hash": info_hash,
+                                "magnet": None,
+                                "link": download_link,
+                                "source": "nekobt",
+                                "seeders": seeders,
+                                "leechers": leechers
+                            }
+                            normalized.append(item)
+                        return normalized
+                    else:
+                        logging.warning(f"NekoBT Error {response.status}")
+            except Exception as e:
+                logging.error(f"NekoBT Exception: {e}")
+        return []
+
+    async def search_movie(self, title, year, imdb_id=None, tmdb_id=None):
+        params = {"q": f"{title} {year}"}
+        return await self.search(params)
+
+    async def search_series(self, title, season, episode, imdb_id=None, tmdb_id=None):
+        # Méthode inspirée de UwU-FR : Lancer plusieurs requêtes en parallèle pour contourner 
+        # la limite de 50/100 résultats de l'API NekoBT et trouver les vieux épisodes/packs.
+        queries = [title]
+        if season is not None and episode is not None:
+            queries.append(f"{title} S{season:02d}E{episode:02d}")
+            queries.append(f"{title} {episode:02d}")
+            queries.append(f"{title} S{season:02d}")
+            queries.append(f"{title} Saison {season}")
+            queries.append(f"{title} Integrale")
+            
+        all_results = []
+        seen_hashes = set()
+        
+        # Exécution parallèle via asyncio.gather
+        import asyncio
+        tasks = [self.search({"q": q, "limit": "100"}) for q in set(queries)]
+        results_list = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        for res in results_list:
+            if isinstance(res, list):
+                for item in res:
+                    info_hash = item.get('info_hash')
+                    if info_hash and info_hash not in seen_hashes:
+                        seen_hashes.add(info_hash)
+                        all_results.append(item)
+                        
+        return all_results

--- a/services/nekobt.py
+++ b/services/nekobt.py
@@ -125,6 +125,12 @@ class NekoBTService:
         if absolute_episode is not None and absolute_episode != episode:
             queries.append(f"{title} {absolute_episode:02d}")
             queries.append(f"{title} S01E{absolute_episode:02d}")
+        # OVA / Spéciaux (saison 0) : nommage fansub sans SxxExx
+        if season == 0 and episode is not None:
+            queries.append(f"{title} OVA")
+            queries.append(f"{title} OAV")
+            queries.append(f"{title} Special")
+            queries.append(f"{title} OVA {episode:02d}")
             
         all_results = []
         seen_hashes = set()

--- a/services/nekobt.py
+++ b/services/nekobt.py
@@ -128,10 +128,13 @@ class NekoBTService:
             
         all_results = []
         seen_hashes = set()
-        
-        # Exécution parallèle via asyncio.gather
+
+        # Lancement étalé (300ms) pour ne pas déclencher de rate-limit
         import asyncio
-        tasks = [self.search({"q": q, "limit": "100"}) for q in set(queries)]
+        tasks = []
+        for q in dict.fromkeys(queries):
+            tasks.append(asyncio.create_task(self.search({"q": q, "limit": "100"})))
+            await asyncio.sleep(0.3)
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
         
         for res in results_list:

--- a/services/nekobt.py
+++ b/services/nekobt.py
@@ -111,8 +111,8 @@ class NekoBTService:
         params = {"q": f"{title} {year}"}
         return await self.search(params)
 
-    async def search_series(self, title, season, episode, imdb_id=None, tmdb_id=None):
-        # Méthode inspirée de UwU-FR : Lancer plusieurs requêtes en parallèle pour contourner 
+    async def search_series(self, title, season, episode, imdb_id=None, tmdb_id=None, absolute_episode=None):
+        # Méthode inspirée de UwU-FR : Lancer plusieurs requêtes en parallèle pour contourner
         # la limite de 50/100 résultats de l'API NekoBT et trouver les vieux épisodes/packs.
         queries = [title]
         if season is not None and episode is not None:
@@ -121,6 +121,10 @@ class NekoBTService:
             queries.append(f"{title} S{season:02d}")
             queries.append(f"{title} Saison {season}")
             queries.append(f"{title} Integrale")
+        # Numérotation absolue anime (ex: "One Piece 1122", "One Piece S01E1122")
+        if absolute_episode is not None and absolute_episode != episode:
+            queries.append(f"{title} {absolute_episode:02d}")
+            queries.append(f"{title} S01E{absolute_episode:02d}")
             
         all_results = []
         seen_hashes = set()

--- a/services/nyaa.py
+++ b/services/nyaa.py
@@ -1,0 +1,126 @@
+import aiohttp
+import logging
+import urllib.parse
+import xml.etree.ElementTree as ET
+import re
+
+class NyaaService:
+    def __init__(self):
+        self.base_url = "https://nyaa.si/"
+
+    async def search(self, params):
+        params['page'] = 'rss'
+        params['c'] = '0_0' # All categories
+        params['f'] = '0'   # No filter
+        
+        logging.info(f"Nyaa Search: {self.base_url}?{urllib.parse.urlencode(params)}")
+
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            try:
+                async with session.get(self.base_url, params=params, timeout=20) as response:
+                    if response.status == 200:
+                        text = await response.text()
+                        
+                        try:
+                            root = ET.fromstring(text)
+                        except ET.ParseError as e:
+                            logging.error(f"Nyaa XML Parse Error: {e}")
+                            return []
+
+                        items = root.findall('.//item')
+                        logging.info(f"Nyaa found {len(items)} results")
+                        
+                        normalized = []
+                        for res in items:
+                            title = res.findtext('title')
+                            description = res.findtext('description', default='')
+                            
+                            # Filtre strict FR : on rejette tout ce qui n'a pas de tag FR/VF/VOSTFR dans le titre ou la description
+                            title_upper = (title or "").upper()
+                            desc_upper = description.upper()
+                            
+                            has_fr_in_title = any(kw in title_upper for kw in ["FRENCH", "VOSTFR", "SUBFRENCH", "TRUEFRENCH", "VFF", "VF2", "VFQ"]) or re.search(r'\bVF\b', title_upper) or re.search(r'\bFR\b', title_upper)
+                            has_fr_in_desc = any(kw in desc_upper for kw in ["FRENCH", "FRANCAIS", "FRANÇAIS", "VOSTFR"]) or re.search(r'\bVF\b', desc_upper) or re.search(r'\bFR\b', desc_upper)
+                            
+                            if not has_fr_in_title and not has_fr_in_desc:
+                                continue # Skip this result as it has no French/VOSTFR
+                                
+                            # Nyaa custom namespace for properties
+                            nyaa_ns = {'nyaa': 'https://nyaa.si/xmlns/nyaa'}
+                            
+                            seeders = res.findtext('nyaa:seeders', namespaces=nyaa_ns)
+                            leechers = res.findtext('nyaa:leechers', namespaces=nyaa_ns)
+                            size_str = res.findtext('nyaa:size', namespaces=nyaa_ns) # usually like "1.4 GiB"
+                            info_hash = res.findtext('nyaa:infoHash', namespaces=nyaa_ns)
+                            download_link = res.findtext('link')
+                            
+                            # Convert size string to bytes roughly (Frenchio uses size in bytes)
+                            size_bytes = 0
+                            if size_str:
+                                try:
+                                    parts = size_str.strip().split()
+                                    if len(parts) == 2:
+                                        val = float(parts[0])
+                                        unit = parts[1].lower()
+                                        if 'gib' in unit or 'gb' in unit:
+                                            size_bytes = int(val * 1024 * 1024 * 1024)
+                                        elif 'mib' in unit or 'mb' in unit:
+                                            size_bytes = int(val * 1024 * 1024)
+                                        elif 'kib' in unit or 'kb' in unit:
+                                            size_bytes = int(val * 1024)
+                                        else:
+                                            size_bytes = int(val)
+                                except Exception:
+                                    size_bytes = 0
+
+                            if not info_hash:
+                                continue
+
+                            item = {
+                                "name": title,
+                                "size": size_bytes,
+                                "tracker_name": "Nyaa",
+                                "info_hash": info_hash,
+                                "magnet": None,
+                                "link": download_link,
+                                "source": "nyaa",
+                                "seeders": int(seeders) if seeders else 0,
+                                "leechers": int(leechers) if leechers else 0
+                            }
+                            normalized.append(item)
+                        return normalized
+                    else:
+                        logging.warning(f"Nyaa Error {response.status}")
+            except Exception as e:
+                logging.error(f"Nyaa Exception: {e}")
+        return []
+
+    async def search_movie(self, title, year, imdb_id=None, tmdb_id=None):
+        params = {"q": f"{title} {year}"}
+        return await self.search(params)
+
+    async def search_series(self, title, season, episode, imdb_id=None, tmdb_id=None):
+        queries = [title]
+        if season is not None and episode is not None:
+            queries.append(f"{title} S{season:02d}E{episode:02d}")
+            queries.append(f"{title} {episode:02d}")
+            queries.append(f"{title} S{season:02d}")
+            queries.append(f"{title} Saison {season}")
+            queries.append(f"{title} Integrale")
+            
+        all_results = []
+        seen_hashes = set()
+        
+        import asyncio
+        tasks = [self.search({"q": q}) for q in set(queries)]
+        results_list = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        for res in results_list:
+            if isinstance(res, list):
+                for item in res:
+                    info_hash = item.get('info_hash')
+                    if info_hash and info_hash not in seen_hashes:
+                        seen_hashes.add(info_hash)
+                        all_results.append(item)
+                        
+        return all_results

--- a/services/nyaa.py
+++ b/services/nyaa.py
@@ -99,7 +99,7 @@ class NyaaService:
         params = {"q": f"{title} {year}"}
         return await self.search(params)
 
-    async def search_series(self, title, season, episode, imdb_id=None, tmdb_id=None):
+    async def search_series(self, title, season, episode, imdb_id=None, tmdb_id=None, absolute_episode=None):
         queries = [title]
         if season is not None and episode is not None:
             queries.append(f"{title} S{season:02d}E{episode:02d}")
@@ -107,6 +107,10 @@ class NyaaService:
             queries.append(f"{title} S{season:02d}")
             queries.append(f"{title} Saison {season}")
             queries.append(f"{title} Integrale")
+        # Numérotation absolue anime (ex: "One Piece 1122", "One Piece S01E1122")
+        if absolute_episode is not None and absolute_episode != episode:
+            queries.append(f"{title} {absolute_episode:02d}")
+            queries.append(f"{title} S01E{absolute_episode:02d}")
             
         all_results = []
         seen_hashes = set()

--- a/services/nyaa.py
+++ b/services/nyaa.py
@@ -120,6 +120,12 @@ class NyaaService:
         if absolute_episode is not None and absolute_episode != episode:
             queries.append(f"{title} {absolute_episode:02d}")
             queries.append(f"{title} S01E{absolute_episode:02d}")
+        # OVA / Spéciaux (saison 0) : nommage fansub sans SxxExx
+        if season == 0 and episode is not None:
+            queries.append(f"{title} OVA")
+            queries.append(f"{title} OAV")
+            queries.append(f"{title} Special")
+            queries.append(f"{title} OVA {episode:02d}")
             
         all_results = []
         seen_hashes = set()

--- a/services/nyaa.py
+++ b/services/nyaa.py
@@ -1,4 +1,5 @@
 import aiohttp
+import asyncio
 import logging
 import urllib.parse
 import xml.etree.ElementTree as ET
@@ -8,17 +9,26 @@ class NyaaService:
     def __init__(self):
         self.base_url = "https://nyaa.si/"
 
-    async def search(self, params):
+    async def search(self, params, max_attempts=3):
         params['page'] = 'rss'
         params['c'] = '0_0' # All categories
         params['f'] = '0'   # No filter
-        
+
         logging.info(f"Nyaa Search: {self.base_url}?{urllib.parse.urlencode(params)}")
 
         async with aiohttp.ClientSession(trust_env=True) as session:
             try:
-                async with session.get(self.base_url, params=params, timeout=20) as response:
-                    if response.status == 200:
+                for attempt in range(max_attempts):
+                    # Nyaa throttle vite (429 dès ~8 requêtes simultanées) : backoff + retry
+                    if attempt > 0:
+                        await asyncio.sleep(1.0 * attempt)
+                    async with session.get(self.base_url, params=params, timeout=20) as response:
+                        if response.status == 429:
+                            logging.warning(f"Nyaa 429 rate-limit (tentative {attempt + 1}/{max_attempts})")
+                            continue
+                        if response.status != 200:
+                            logging.warning(f"Nyaa Error {response.status}")
+                            return []
                         text = await response.text()
                         
                         try:
@@ -89,8 +99,7 @@ class NyaaService:
                             }
                             normalized.append(item)
                         return normalized
-                    else:
-                        logging.warning(f"Nyaa Error {response.status}")
+                logging.warning(f"Nyaa: abandon après {max_attempts} tentatives (rate-limit)")
             except Exception as e:
                 logging.error(f"Nyaa Exception: {e}")
         return []
@@ -114,9 +123,12 @@ class NyaaService:
             
         all_results = []
         seen_hashes = set()
-        
-        import asyncio
-        tasks = [self.search({"q": q}) for q in set(queries)]
+
+        # Lancement étalé (300ms) pour ne pas déclencher le rate-limit de Nyaa
+        tasks = []
+        for q in dict.fromkeys(queries):
+            tasks.append(asyncio.create_task(self.search({"q": q})))
+            await asyncio.sleep(0.3)
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
         
         for res in results_list:

--- a/templates/configure.html
+++ b/templates/configure.html
@@ -833,6 +833,40 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- Nyaa -->
+                <div class="provider-card" id="providerNyaa" onclick="toggleProvider('providerNyaa')">
+                    <div class="provider-header">
+                        <span class="provider-name">
+                            <span class="provider-dot"></span>
+                            Nyaa
+                        </span>
+                        <span class="provider-chevron">▼</span>
+                    </div>
+                    <div class="provider-body">
+                        <div class="form-group" style="display:flex; align-items:center; gap:8px; padding-top: 5px;">
+                            <input type="checkbox" id="nyaaEnabled" style="width:auto; margin:0;" onclick="event.stopPropagation()">
+                            <label for="nyaaEnabled" style="margin:0;">Activer Nyaa</label>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- NekoBT -->
+                <div class="provider-card" id="providerNeko" onclick="toggleProvider('providerNeko')">
+                    <div class="provider-header">
+                        <span class="provider-name">
+                            <span class="provider-dot"></span>
+                            NekoBT
+                        </span>
+                        <span class="provider-chevron">▼</span>
+                    </div>
+                    <div class="provider-body">
+                        <div class="form-group">
+                            <label for="nekoApikey">Clé API Torznab</label>
+                            <input type="text" id="nekoApikey" placeholder="Clé API" onclick="event.stopPropagation()">
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -881,6 +915,12 @@
                     débridées restent toujours en premier). L'ordre par Tracker utilisera le drag & drop
                     ci-dessous.</span>
             </div>
+
+            <div class="form-group" style="display:flex; align-items:center; gap:8px; padding-top: 15px;">
+                <input type="checkbox" id="excludeSeasonPacks" style="width:auto; margin:0;">
+                <label for="excludeSeasonPacks" style="margin:0;">Exclure les packs de saison complets</label>
+            </div>
+            <span class="help-text" style="margin-top:-5px;">Masque les torrents "Saison Complète" ou "Intégrale" pour n'afficher que les épisodes à l'unité. Utile si vous avez une connexion/stockage limité.</span>
         </div>
 
         <!-- Ordre de priorité -->
@@ -941,6 +981,8 @@
                 <li class="sortable-item" data-id="abn"><span class="drag-handle">≡</span> 🎬 ABN</li>
                 <li class="sortable-item" data-id="c411"><span class="drag-handle">≡</span> 📡 C411</li>
                 <li class="sortable-item" data-id="tr4ker"><span class="drag-handle">≡</span> 🎯 Tr4ker</li>
+                <li class="sortable-item" data-id="nyaa"><span class="drag-handle">≡</span> 🐱 Nyaa</li>
+                <li class="sortable-item" data-id="nekobt"><span class="drag-handle">≡</span> 🐾 NekoBT</li>
             </ul>
         </div>
 
@@ -1010,7 +1052,8 @@
                 'providerAbn': ['abnUsername'],
                 'providerC411': ['c411Apikey'],
                 'providerTorr9': ['torr9Passkey'],
-                'providerTr4ker': ['tr4kerApikey']
+                'providerTr4ker': ['tr4kerApikey'],
+                'providerNeko': ['nekoApikey']
             };
             for (const [cardId, inputIds] of Object.entries(providerMap)) {
                 if (cardId === 'providerYgg') continue; // Always active
@@ -1025,11 +1068,20 @@
                     card.classList.remove('active');
                 }
             }
+
+            const nyaaCard = document.getElementById('providerNyaa');
+            const nyaaCheck = document.getElementById('nyaaEnabled');
+            if(nyaaCheck && nyaaCheck.checked) nyaaCard.classList.add('active');
+            else if(nyaaCard) nyaaCard.classList.remove('active');
         }
 
         // Listen for input changes on provider fields
         document.querySelectorAll('.provider-body input').forEach(input => {
-            input.addEventListener('input', updateProviderActiveStates);
+            if (input.type === 'checkbox') {
+                input.addEventListener('change', updateProviderActiveStates);
+            } else {
+                input.addEventListener('input', updateProviderActiveStates);
+            }
         });
 
         // Gestion des radio buttons pour le service de débridage
@@ -1091,11 +1143,13 @@
             document.getElementById('c411Apikey').value = prefillConfig.c411_apikey || '';
             document.getElementById('torr9Passkey').value = prefillConfig.torr9_passkey || '';
             document.getElementById('tr4kerApikey').value = prefillConfig.tr4ker_apikey || '';
+            document.getElementById('nekoApikey').value = prefillConfig.neko_apikey || '';
+            document.getElementById('nyaaEnabled').checked = !!prefillConfig.nyaa_enabled;
 
             // Mettre à jour les états actifs des provider cards
             updateProviderActiveStates();
             // Ouvrir automatiquement les cards remplies
-            ['providerYgg', 'providerAbn', 'providerC411', 'providerTorr9', 'providerTr4ker'].forEach(id => {
+            ['providerYgg', 'providerAbn', 'providerC411', 'providerTorr9', 'providerTr4ker', 'providerNeko', 'providerNyaa'].forEach(id => {
                 const card = document.getElementById(id);
                 if (card && card.classList.contains('active') && id !== 'providerYgg') {
                     card.classList.add('expanded');
@@ -1228,6 +1282,9 @@
             const c411Apikey = document.getElementById('c411Apikey').value.trim();
             const torr9Passkey = document.getElementById('torr9Passkey').value.trim();
             const tr4kerApikey = document.getElementById('tr4kerApikey').value.trim();
+            const nekoApikey = document.getElementById('nekoApikey').value.trim();
+            const nyaaEnabled = document.getElementById('nyaaEnabled').checked;
+            const excludeSeasonPacks = document.getElementById('excludeSeasonPacks').checked;
             const maxSize = parseInt(document.getElementById('maxSize').value) || 0;
             const sortBy = document.getElementById('sortBy').value;
 
@@ -1281,8 +1338,11 @@
                 c411_apikey: c411Apikey,
                 torr9_passkey: torr9Passkey,
                 tr4ker_apikey: tr4kerApikey,
+                neko_apikey: nekoApikey,
+                nyaa_enabled: nyaaEnabled,
                 max_size: maxSize,
                 sort_by: sortBy,
+                exclude_season_packs: excludeSeasonPacks,
                 providers_order: providersOrder,
                 mediaflow: mediaflowProxyUrl ? {
                     proxy_url: mediaflowProxyUrl,

--- a/utils.py
+++ b/utils.py
@@ -232,7 +232,7 @@ def parse_torrent_name(name):
         "release_type": release_type
     }
 
-def check_season_episode(name, target_season, target_episode):
+def check_season_episode(name, target_season, target_episode, exclude_packs=False):
     """
     Vérifie si le torrent correspond à la saison/épisode demandé.
     Retourne True si c'est bon (match exact ou pack saison).
@@ -267,8 +267,10 @@ def check_season_episode(name, target_season, target_episode):
             if season != target_season:
                 continue
                 
-            # Si pas d'épisode dans le nom (Pack Saison) -> OK
+            # Si pas d'épisode dans le nom (Pack Saison) -> OK sauf si on exclut les packs
             if e_start is None:
+                if exclude_packs:
+                    return False
                 return True
                 
             start = int(e_start)

--- a/utils.py
+++ b/utils.py
@@ -232,6 +232,55 @@ def parse_torrent_name(name):
         "release_type": release_type
     }
 
+STOPWORDS_TITLE = {'le', 'la', 'les', 'de', 'des', 'du', 'the', 'of', 'no', 'and', 'et', 'wa', 'to', 'ni'}
+
+def check_title_tokens(name, *titles):
+    """
+    Vérification de titre souple pour les nommages fansub (Nyaa/NekoBT) :
+    tous les mots significatifs d'un des titres doivent apparaître entiers
+    dans le nom du torrent. Évite les hors-sujet du type "Monster" qui
+    matche "Pocket Monsters" via un pack/range d'épisodes.
+    """
+    name_words = set(normalize_title(name).split())
+    for title in titles:
+        if not title:
+            continue
+        tokens = [w for w in normalize_title(title).split()
+                  if len(w) >= 2 and w not in STOPWORDS_TITLE]
+        if tokens and all(tok in name_words for tok in tokens):
+            return True
+    return False
+
+def check_special_episode(name, target_episode, exclude_packs=False):
+    """
+    Vérifie si le torrent correspond à un épisode spécial/OVA (saison 0)
+    au nommage fansub : "Titre OVA 06 VOSTFR", "OAV 1+2", "S01 + OAV",
+    ou le classique "S00E01".
+    """
+    if check_season_episode(name, 0, target_episode, exclude_packs=exclude_packs):
+        return True
+    name_upper = name.upper()
+    if not re.search(r'\b(?:OVA|OAV|OAD|SPECIALS?|SP)\b', name_upper):
+        return False
+    # Numéros accolés au tag : "OVA 06", "OAV 1+2", "Special 3"
+    nums = re.findall(r'\b(?:OVA|OAV|OAD|SPECIALS?|SP)\b[ ._#-]*0*(\d{1,3})(?:[ ._+~-]+0*(\d{1,3}))?', name_upper)
+    if not nums:
+        # Tag OVA sans numéro : pack d'OVA ou bundle ("S01 + OAV")
+        return not exclude_packs
+    for start, end in nums:
+        try:
+            s = int(start)
+            e = int(end) if end else s
+            if s > e:
+                s, e = e, s
+            if s != e and exclude_packs:
+                continue
+            if s <= target_episode <= e:
+                return True
+        except ValueError:
+            continue
+    return False
+
 def check_absolute_episode(name, absolute_episode, exclude_packs=False):
     """
     Vérifie si le torrent correspond à l'épisode en numérotation absolue,

--- a/utils.py
+++ b/utils.py
@@ -232,6 +232,49 @@ def parse_torrent_name(name):
         "release_type": release_type
     }
 
+def check_absolute_episode(name, absolute_episode, exclude_packs=False):
+    """
+    Vérifie si le torrent correspond à l'épisode en numérotation absolue,
+    utilisée par les fansubs anime (ex: "One Piece S01E1122", "One Piece - 1122 VOSTFR",
+    ou un pack "One Piece 1100-1150").
+    """
+    if absolute_episode is None:
+        return False
+    name_upper = name.upper()
+
+    # SxxEyyyy : numérotation absolue déguisée en saison 1 (ex: S01E1122, avec ranges S01E1100-1150)
+    se_pattern = re.compile(r'(?:S|SAISON|SEASON)[ ._-]?0?1[ ._-]?E(\d{1,4})(?:[ ._-]*(?:E|-|~)[ ._-]*(\d{1,4}))?', re.IGNORECASE)
+    for e_start, e_end in se_pattern.findall(name_upper):
+        try:
+            start = int(e_start)
+            end = int(e_end) if e_end else start
+            if end < start:
+                continue
+            if start < end and exclude_packs:
+                continue
+            if start <= absolute_episode <= end:
+                return True
+        except ValueError:
+            continue
+
+    # Ranges nus (packs) : "1100-1150"
+    if not exclude_packs:
+        range_pattern = re.compile(r'(?<![0-9])(\d{2,4})[ ._]?[-~][ ._]?(\d{2,4})(?![0-9])')
+        for r_start, r_end in range_pattern.findall(name_upper):
+            try:
+                start, end = int(r_start), int(r_end)
+                if start < end and start <= absolute_episode <= end:
+                    return True
+            except ValueError:
+                continue
+
+    # Numéro nu : "- 1122", "E1122", "EP1122" (en excluant 1080P, X264, H.264...)
+    bare_pattern = re.compile(rf'(?<![0-9])(?<!X)(?<!H\.)0*{absolute_episode}(?![0-9])(?!P\b)')
+    if bare_pattern.search(name_upper):
+        return True
+
+    return False
+
 def check_season_episode(name, target_season, target_episode, exclude_packs=False):
     """
     Vérifie si le torrent correspond à la saison/épisode demandé.


### PR DESCRIPTION
## Résumé

Cette PR reprend l'excellent travail de @pixelroll (#18) — intégration de Nyaa.si et NekoBT comme sources animes sans ratio — et y ajoute trois améliorations découvertes en la testant en conditions réelles. Le premier commit est la #18 telle quelle (créditée en co-auteur) ; si #18 est mergée d'abord, je rebaserai celle-ci sur les trois commits restants.

## Ce qui est ajouté par rapport à #18

### 1. Numérotation absolue des épisodes
Les fansubs nomment les animes au long cours en numérotation absolue (`One Piece S01E1122`) alors que Stremio demande `S22E5`. Sans conversion, la #18 ne trouve quasiment rien sur One Piece, Détective Conan, Boruto, etc. :
- l'épisode absolu est calculé depuis le découpage des saisons TMDB **déjà présent dans `media_info`** (zéro requête réseau supplémentaire) ;
- deux requêtes supplémentaires par source (`{titre} {absolu}`, `{titre} S01E{absolu}`) ;
- `check_absolute_episode()` dans utils.py accepte ce nommage au filtrage (avec exclusion des faux positifs `1080p`/`x264`/`H.264`, y compris le cas de l'épisode 1080 face à un torrent 1080p).

**Testé en live** : One Piece S22E5 passe de 0 résultat filtré à 2 résultats corrects (`One Piece S01E1122 VOSTFR` Tsundere-Raws).

### 2. Fix rate-limit nyaa.si
nyaa.si renvoie des HTTP 429 dès ~8 requêtes simultanées : le `asyncio.gather` en burst de la #18 perd des résultats au hasard (constaté : Spy x Family S02E05 tombait de 5 à 1 résultat selon les runs). Correctif : lancement étalé à 300 ms + 3 tentatives avec backoff progressif sur 429.

### 3. OVA/spéciaux (saison 0) + garde-fou titre
- Quand Stremio demande la saison 0, requêtes `OVA`/`OAV`/`Special` et matching du nommage fansub (`Titre OVA 06`, `OAV 1+2`, packs `S01 + OAV`) via `check_special_episode()`. Avant : 0 résultat sur les OVA ; après : 6 résultats sur One Punch Man S00E01.
- La #18 désactive le filtre de titre pour Nyaa/NekoBT, ce qui laisse passer des hors-sujet via les packs/ranges (ex. packs « Pocket Monsters » retournés pour « Monster »). `check_title_tokens()` exige les mots du titre sur les acceptations molles (packs, ranges, absolu) tout en laissant intacts les matchs `SxxExx` exacts.

## Tests
- 23 cas de test unitaires sur les trois nouvelles fonctions de utils.py ;
- banc de test live contre nyaa.si sur 7 cas d'usage (épisode récent, long cours, titre FR ≠ romaji, saison 2 standard, vieux anime, OVA, film) ;
- `APP_VERSION` non modifiée, je vous laisse la main sur le versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)